### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+# Code of Conduct
+
+This code of conduct outlines our expectations for all those who participate
+in the Co-Log organization.
+
+We invite all those who participate in Co-Log to help us to create safe
+and positive experiences for everyone.
+
+## Our Standards
+
+A primary goal of Co-Log is to make the open source community friendlier.
+As such, we are committed to providing a friendly, safe and welcoming environment for all.
+So, we are using the following standards in our organization.
+
+### Be inclusive.
+
+We welcome and support people of all backgrounds and identities. This includes,
+but is not limited to members of any sexual orientation, gender identity and expression,
+race, ethnicity, culture, national origin, social and economic class, educational level,
+colour, immigration status, sex, age, size, family status, political belief, religion,
+and mental and physical ability.
+
+### Be respectful.
+
+We won't all agree all the time, but disagreement is no excuse for disrespectful behaviour.
+We will all experience frustration from time to time, but we cannot allow that frustration
+to become personal attacks. An environment where people feel uncomfortable or threatened
+is not a productive or creative one.
+
+### Choose your words carefully.
+
+Always conduct yourself professionally. Be kind to others. Do not insult or put down others.
+Harassment and exclusionary behaviour aren't acceptable. This includes, but is not limited to:
+
+  * Threats of violence.
+  * Discriminatory language.
+  * Personal insults, especially those using racist or sexist terms.
+  * Advocating for, or encouraging, any of the above behaviours.
+
+### Don't harass.
+
+In general, if someone asks you to stop something, then stop. When we disagree, try to understand why.
+Differences of opinion and disagreements are mostly unavoidable. What is important is that we resolve
+disagreements and differing views constructively.
+
+### Make differences into strengths.
+
+Different people have different perspectives on issues,
+and that can be valuable for solving problems or generating new ideas. Being unable to understand why
+someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that we all make mistakes,
+and blaming each other doesn’t get us anywhere.
+
+Instead, focus on resolving issues and learning from mistakes.
+
+##  Reporting Guidelines
+
+If you are subject to or witness unacceptable behaviour, or have any other concerns,
+please notify admins of the Co-Log organization as soon as possible.
+
+You can reach them via the following email address:
+
+ * xrom.xkov@gmail.com

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ and positive experiences for everyone.
 
 ## Our Standards
 
-A primary goal of Co-Log is to make the open source community friendlier.
+The main concern of Co-Log is friendliness and inclusion.
 As such, we are committed to providing a friendly, safe and welcoming environment for all.
 So, we are using the following standards in our organization.
 


### PR DESCRIPTION
It's copied from the [Kowainik's Code of Conduct](https://github.com/kowainik/.github/blob/main/CODE_OF_CONDUCT.md). I changed the organization name and the last two sentences to make it more generic. But overall, it's the same, and I'm still quite happy with the wording 🙂